### PR TITLE
Small fixes for lint/ci/psr

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Pimcore
  *
@@ -11,6 +12,7 @@
  * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
+
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\Kernel;
 

--- a/app/Resources/views/Default/default.html.php
+++ b/app/Resources/views/Default/default.html.php
@@ -11,7 +11,7 @@
     body {
         padding:0;
         margin: 0;
-        font-family: "Lucida Sans Unicode", Arial;
+        font-family: "Lucida Sans Unicode", Arial, sans-serif;
         font-size: 14px;
     }
 
@@ -102,7 +102,7 @@
 
 <div id="site">
     <div id="logo">
-        <a href="http://www.pimcore.com/"><img src="/bundles/pimcoreadmin/img/logo-claim-gray.svg" style="width: 400px;" /></a>
+        <a href="http://www.pimcore.com/"><img src="/bundles/pimcoreadmin/img/logo-claim-gray.svg" alt="Logo claim grey" style="width: 400px;" /></a>
         <hr />
     </div>
 


### PR DESCRIPTION
Hello,

These are very very small improvements, but help for CI so it does not report warning/error, as `app` should be tested against lint tools. Better to fix it at the base than each time a project is created.

It makes app ok for styleint, htmlint and psr check (except `Each class must be in a namespace of at least one level (a top-level vendor name)` but we can do nothing on this one).

Thanks.

