### PR TITLE
Console can now find autoload

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -15,7 +15,17 @@
 
 ob_get_clean();
 
-include __DIR__ . "/../vendor/autoload.php";
+if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
+    include $a;
+} elseif (file_exists($a = __DIR__ . '/../../../../vendor/autoload.php')) {
+    include $a;
+} elseif (file_exists($a = __DIR__ . '/../autoload.php')) {
+    include $a;
+} else {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
+
 \Pimcore\Bootstrap::setProjectRoot();
 
 define('PIMCORE_CONSOLE', true);


### PR DESCRIPTION
When i was upgrading Pimcore via:

https://pimcore.com/docs/5.x/Development_Documentation/Installation_and_Upgrade/Upgrade_Notes/Within_V5/Update_from_5.x_to_5.4_or_above.html

On Step 8, I had to use this file via:

`wget https://raw.githubusercontent.com/pimcore/skeleton/master/bin/console -O bin/console`

When I ran `./bin/conole -h` it couldn't find autoload, so this fixed worked form me