### PR TITLE
Automatically execute bundle migrations on composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
       "Pimcore\\Composer::postUpdate",
       "@pimcore-scripts",
       "Pimcore\\Composer::executeMigrationsUp",
+      "Pimcore\\Composer::executeBundleMigrationsUp",
       "@pimcore-scripts"
     ],
     "pimcore-scripts": [


### PR DESCRIPTION
This PR calls the Composer script to execute bundle migrations when executing `composer update`.