### PR TITLE
Load bundle dependencies of manually installed bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
     "symfony-assets-install": "relative",
     "merge-plugin": {
       "include": [
-        "composer.local.json"
+        "composer.local.json",
+        "src/*/composer.json"
       ],
       "recurse": true,
       "replace": true,


### PR DESCRIPTION
We offer two ways of installation for our private / paid bundles: 
1. via Composer (customer gets access to private git repository, can add that repository to composer.json `repositories` block and then `require` the bundle)
2. Send a zip file with the latest tagged version of the bundle which the customer can put into his Pimcore's `src/` folder. Theoretically this works but as soon as the bundle uses other libraries as dependencies these are not available.

When doing 1. bundle dependencies get automatically resolved and added to the root vendor folder. 
With this PR this also does apply for the manual installation approach.