### PR TITLE
Replace getcwd() to dirname for include autoloader

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -15,7 +15,7 @@
 
 ob_get_clean();
 
-if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
+if (file_exists($a = dirname(__DIR__) . '/vendor/autoload.php')) {
     include $a;
 } elseif (file_exists($a = __DIR__ . '/../../../../vendor/autoload.php')) {
     include $a;


### PR DESCRIPTION
Hi!

**Pre-conditions**

1. New project on latest skeleton
2. Configured Workflow and installed Graphviz or another tool that use Pimcore\Tool\Console::exec method

**Actual result**
Result is NULL, because shell_exec run with error and for command:
/usr/bin/php /var/www/pimcore-skeleton/www/bin/console pimcore:workflow:dump Product NewItem | /usr/bin/dot -Tsvg 

Issue is related with bin/console and it can't load autoloader and return  'Cannot locate autoloader; please run "composer install"' implemented in https://github.com/pimcore/skeleton/pull/21

Please review,