### PR TITLE
[Followup] Remove composer merge plugin extra options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,17 +48,6 @@
     "symfony-var-dir": "var",
     "symfony-web-dir": "web",
     "symfony-tests-dir": "tests",
-    "symfony-assets-install": "relative",
-    "merge-plugin": {
-      "include": [
-        "composer.local.json"
-      ],
-      "recurse": true,
-      "replace": true,
-      "merge-dev": true,
-      "merge-extra": false,
-      "merge-extra-deep": false,
-      "merge-scripts": false
-    }
+    "symfony-assets-install": "relative"
   }
 }


### PR DESCRIPTION
Now that `composer-merge-plugin` was removed in 587e589, its extra options are not needed anymore.