### PR TITLE
Remove merge-plugin completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,6 @@
 /.php_cs
 /.php_cs.cache
 
-# composer.local.json is referenced in composer-merge-plugin
-# remove this for your projects if you want to track the file
-/composer.local.json
-
 # composer
 /vendor/
 

--- a/composer.json
+++ b/composer.json
@@ -48,17 +48,6 @@
     "symfony-var-dir": "var",
     "symfony-web-dir": "web",
     "symfony-tests-dir": "tests",
-    "symfony-assets-install": "relative",
-    "merge-plugin": {
-      "include": [
-        "composer.local.json"
-      ],
-      "recurse": true,
-      "replace": true,
-      "merge-dev": true,
-      "merge-extra": false,
-      "merge-extra-deep": false,
-      "merge-scripts": false
-    }
+    "symfony-assets-install": "relative"
   }
 }


### PR DESCRIPTION
Remove `merge-plugin` completely in the `2.8` branch.