### PR TITLE
[Composer] Disable timeout for scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "license": "GPL-3.0-or-later",
   "config": {
     "optimize-autoloader": true,
-    "sort-packages": true
+    "sort-packages": true,
+    "process-timeout": 0
   },
   "require": {
     "pimcore/pimcore": "7.0.x-dev as 6.8.x-dev"


### PR DESCRIPTION
We have a customer with ~3.3 million data objects. Executing database migrations for a Pimcore upgrade takes a very long time there. After doing `composer update` by default core database migrations get executed automatically. For some migrations it is bad when they get aborted in the middle of the process because when you just start them again they do not work because SOME statements have been executed (even with `--all-or-nothing` as [some statements cause an implicit commit and are not possible to be rolled back](https://stackoverflow.com/questions/22806261/can-i-use-transactions-with-alter-table)). In this case then you have to manually execute the remaining statements which is really painful.

Even more annoying is when the abortion is not caused by a real error but from a timeout. And as scripts which get executed by composer have a [default timeout of 300 seconds](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands), migration execution might get aborted due to this timeout when you have some more data objects. This PR disables this timeout.