### PR TITLE
Process input for --env and --no-debug for bin/console - Symfony 5

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -30,6 +30,16 @@ if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
 
 define('PIMCORE_CONSOLE', true);
 
+
+$input = new \Symfony\Component\Console\Input\ArgvInput();
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+}
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
 /** @var \Pimcore\Kernel $kernel */
 $kernel = \Pimcore\Bootstrap::startupCli();
 $application = new \Pimcore\Console\Application($kernel);


### PR DESCRIPTION
similar to the original bin/console from symfony: https://github.com/symfony/recipes/blob/master/symfony/console/5.1/bin/console