### PR TITLE
Remove unused namespace import HWIOAuthBundle

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,7 +14,6 @@
 
 namespace App;
 
-use HWI\Bundle\OAuthBundle\HWIOAuthBundle;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\Kernel as PimcoreKernel;
 


### PR DESCRIPTION
Fixup for 65932809d65.