### PR TITLE
Update config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -116,6 +116,10 @@ pimcore:
 #### SYMFONY OVERRIDES
 framework:
 
+#### DEFINE LOCATION OF MANIFEST WHEN WORKING WITH SYMFONY ENCORE
+#    assets:
+#        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
+
 #### USE CUSTOM CACHE POOL
 #    cache:
 #        pools:


### PR DESCRIPTION
When using Symfony Encore, asset filenames can have versioning file suffixes. When using the symfony/asset twig extension, the files can be found without versioning suffix (usually in DEV mode). When versioning is enabled (PROD environment) the files cannot be located anymore, when the location of the manifest.json is not configured.