### PR TITLE
docker-compose.yml : use Nginx incl. an improved Xdebug handling

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,165 @@
+# mime types are covered in nginx.conf by:
+# http {
+#   include       mime.types;
+# }
+
+upstream php-pimcore10 {
+    server php-fpm:9000;
+}
+
+
+upstream php-pimcore10-debug {
+    server php-fpm-debug:9000;
+}
+
+server {
+    listen 80 default_server ;
+    #server_name pimcore.localhost;
+    root /var/www/html/public;
+    index index.php;
+
+    # Filesize depending on your data
+    client_max_body_size 100m;
+
+    # It is recommended to seclude logs per virtual host
+    #access_log  /var/log/access.log;
+    #error_log   /var/log/error.log error;
+
+    # Protected Assets
+    #
+    ### 1. Option - Restricting access to certain assets completely
+    #
+    # location ~ ^/protected/.* {
+    #   return 403;
+    # }
+    # location ~ ^/var/.*/protected(.*) {
+    #   return 403;
+    # }
+    #
+    # location ~ ^/cache-buster\-[\d]+/protected(.*) {
+    #   return 403;
+    # }
+    #
+    ### 2. Option - Checking permissions before delivery
+    #
+    # rewrite ^(/protected/.*) /index.php$is_args$args last;
+    #
+    # location ~ ^/var/.*/protected(.*) {
+    #   return 403;
+    # }
+    #
+    # location ~ ^/cache-buster\-[\d]+/protected(.*) {
+    #   return 403;
+    # }
+
+    # Pimcore Head-Link Cache-Busting
+    rewrite ^/cache-buster-(?:\d+)/(.*) /$1 last;
+
+    # Stay secure
+    #
+    # a) don't allow PHP in folders allowing file uploads
+    location ~* /var/assets/.*\.php(/|$) {
+        return 404;
+    }
+
+    # b) Prevent clients from accessing hidden files (starting with a dot)
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known/) {
+        deny all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # c) Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf(ig)?|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    # Some Admin Modules need this:
+    # Database Admin, Server Info
+    location ~* ^/admin/(adminer|external) {
+        rewrite .* /index.php$is_args$args last;
+    }
+
+    # Thumbnails
+    location ~* .*/(image|video)-thumb__\d+__.* {
+        try_files /var/tmp/thumbnails$uri /index.php;
+        expires 2w;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # Assets
+    # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
+    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
+        try_files /var/assets$uri $uri =404;
+        expires 2w;
+        access_log off;
+        log_not_found off;
+        add_header Cache-Control "public";
+    }
+
+    location / {
+        error_page 404 /meta/404;
+        try_files $uri /index.php$is_args$args;
+    }
+
+    # Use this location when the installer has to be run
+    # location ~ /(index|install)\.php(/|$) {
+    #
+    # Use this after initial install is done:
+    location ~ ^/index\.php(/|$) {
+        send_timeout 1800;
+        fastcgi_read_timeout 1800;
+        # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        # Check that the PHP script exists before passing it
+        #try_files $fastcgi_script_name =404;
+        # include fastcgi.conf if needed
+        include fastcgi_params;
+        # Bypass the fact that try_files resets $fastcgi_path_info
+        # see: http://trac.nginx.org/nginx/ticket/321
+        set $path_info $fastcgi_path_info;
+        fastcgi_param PATH_INFO $path_info;
+
+        # Activate these, if using Symlinks and opcache
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+        # If Xdebug session is requested, pass it to the Xdebug enabled container
+        if ($http_cookie ~* "XDEBUG_SESSION") {
+            fastcgi_pass php-pimcore10-debug;
+        }
+
+        fastcgi_pass php-pimcore10;
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/index.php/some-path
+        # Remove the internal directive to allow URIs like this
+        internal;
+    }
+
+    # PHP-FPM Status and Ping
+    location /fpm- {
+        access_log off;
+        include fastcgi_params;
+        location /fpm-status {
+            allow 127.0.0.1;
+            # add additional IP's or Ranges
+            deny all;
+            fastcgi_pass php-pimcore10;
+        }
+        location /fpm-ping {
+            fastcgi_pass php-pimcore10;
+        }
+    }
+    # nginx Status
+    # see: https://nginx.org/en/docs/http/ngx_http_stub_status_module.html
+    location /nginx-status {
+        allow 127.0.0.1;
+        deny all;
+        access_log off;
+        stub_status;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,48 @@
 version: '2.4'
 services:
-  redis:
-    image: redis:alpine
+    redis:
+        image: redis:alpine
 
-  db:
-    image: mariadb:10.5
-    working_dir: /application
-    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-format=Barracuda, --innodb-large-prefix=1, --innodb-file-per-table=1]
-    volumes:
-      - pimcore-database:/var/lib/mysql
-    environment:
-      - MYSQL_ROOT_PASSWORD=ROOT
-      - MYSQL_DATABASE=pimcore
-      - MYSQL_USER=pimcore
-      - MYSQL_PASSWORD=pimcore
+    db:
+        image: mariadb:10.5
+        working_dir: /application
+        command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-format=Barracuda, --innodb-large-prefix=1, --innodb-file-per-table=1]
+        volumes:
+            - pimcore-demo-database:/var/lib/mysql
+        environment:
+            - MYSQL_ROOT_PASSWORD=ROOT
+            - MYSQL_DATABASE=pimcore
+            - MYSQL_USER=pimcore
+            - MYSQL_PASSWORD=pimcore
 
-  php:
-    image: pimcore/pimcore:PHP8.0-apache
-    volumes:
-      - .:/var/www/html:cached
-    ports:
-     - 80:80
-     - 443:443
-    depends_on:
-     - db
-    environment:
-      - APACHE_DOCUMENT_ROOT=/var/www/html/public
+    nginx:
+        image: nginx:stable-alpine
+        ports:
+            - 80:80
+        volumes:
+            - .:/var/www/html:ro
+            - ./.docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
-  php-debug:
-    image: pimcore/pimcore:PHP8.0-apache-debug
-    volumes:
-      - .:/var/www/html:cached
-    ports:
-     - 88:80
-    environment:
-      - PHP_IDE_CONFIG="serverName=localhost"
-      - APACHE_DOCUMENT_ROOT=/var/www/html/public
+    php-fpm:
+        #user: '1000:1000' # set to your uid:gid
+        image: pimcore/pimcore:PHP8.0-fpm
+        depends_on:
+            - db
+        volumes:
+            - .:/var/www/html:cached
+            - pimcore-tmp-storage:/tmp:cached
+
+    php-fpm-debug:
+        #user: '1000:1000' # set to your uid:gid
+        image: pimcore/pimcore:PHP8.0-fpm-debug
+        depends_on:
+            - db
+        volumes:
+            - .:/var/www/html:cached
+            - pimcore-tmp-storage:/tmp:cached
+        environment:
+            - PHP_IDE_CONFIG="serverName=localhost"
 
 volumes:
-  pimcore-database:
+    pimcore-demo-database:
+    pimcore-tmp-storage:


### PR DESCRIPTION
Nginx delegates the incoming request to either the Xdebug enabled PHP container or to the production ready PHP container depending if the `XDEBUG_SESSION` cookie is set or not. 
This improves debugging a lot, since you can develop on the much faster PHP container and as soon as you need a debugger (by triggering in with a browser extension or similar) Nginx automatically switches to the Xdebug enabled container. 

See also pimcore/demo#255