### PR TITLE
fixed docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
         volumes:
             - .:/var/www/html:ro
             - ./.docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+        depends_on:
+            - php-fpm
+            - php-fpm-debug
 
     php-fpm:
         #user: '1000:1000' # set to your uid:gid


### PR DESCRIPTION
nginx would exit if it is loaded before php-fpm is available.

This fixes that.