### PR TITLE
Fix issue with whitespace in Ext.js

### DIFF
--- a/config/pimcore/perspectives.example.php
+++ b/config/pimcore/perspectives.example.php
@@ -61,7 +61,7 @@ return [
         ]
 
     ],
-    'Alternative view' => [
+    'alternative_view' => [
         'icon' => '/bundles/pimcoreadmin/img/flat-color-icons/biohazard.svg',
         'toolbar' => [
             'file' => 1,
@@ -158,7 +158,7 @@ return [
             ]
         ]
     ],
-    'Assets only' => [
+    'assets_only' => [
         'icon' => '/bundles/pimcoreadmin/img/flat-color-icons/webcam.svg',
         'elementTree' => [
             [


### PR DESCRIPTION
Since Pimcore 10.2.0 this seems to cause issues. The file is also linked in the documentation, it does not work that way. Therefore replaced with a name which Ext.js can work with.