### PR TITLE
Remove support for `PimcoreLegacyBundle` in the Kernel

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -31,9 +31,5 @@ class Kernel extends PimcoreKernel
         if (class_exists('\\AppBundle\\AppBundle')) {
             $collection->addBundle(new \AppBundle\AppBundle);
         }
-
-        if (class_exists('\Pimcore\Bundle\LegacyBundle\PimcoreLegacyBundle')) {
-            $collection->addBundle(new \Pimcore\Bundle\LegacyBundle\PimcoreLegacyBundle);
-        }
     }
 }


### PR DESCRIPTION
I suppose it was the bundle from this package: https://github.com/pimcore/pimcore4-compatibility-bridge which is unmaintained and outdated.