### PR TITLE
Remove legacy folders from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,6 @@
 /config/local/*
 !config/local/.gitkeep
 
-# pimcore legacy (remove this for your own development)
-!/legacy
-/legacy/*
-!legacy/.gitkeep
-!legacy/bundle
-
 /var/*
 !/var/.gitkeep
 !/var/classes/
@@ -52,8 +46,5 @@
 # NetBeans
 nbproject
 
-# keep legacy paths ignored for easier migration
-/plugins/
-/tools/
-/website/
+# temp
 .temp


### PR DESCRIPTION
I assume those were folders in Pimcore 4 and aren't needed anymore for an easy migration to Pimcore X.