### PR TITLE
Let nginx listen on IPv6

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -13,8 +13,11 @@ upstream php-pimcore10-debug {
 }
 
 server {
-    listen 80 default_server ;
+    listen [::]:80 default_server;
+    listen 80 default_server;
+    
     #server_name pimcore.localhost;
+    
     root /var/www/html/public;
     index index.php;
 


### PR DESCRIPTION
I think nginx should listen on IPv6 by default.