### PR TITLE
Mitigate https://httpoxy.org/ vulnerabilities in `nginx.conf`

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -7,7 +7,6 @@ upstream php-pimcore10 {
     server php-fpm:9000;
 }
 
-
 upstream php-pimcore10-debug {
     server php-fpm-debug:9000;
 }
@@ -130,6 +129,9 @@ server {
         # Activate these, if using Symlinks and opcache
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+        # Mitigate https://httpoxy.org/ vulnerabilities
+        fastcgi_param HTTP_PROXY "";
 
         # If Xdebug session is requested, pass it to the Xdebug enabled container
         if ($http_cookie ~* "XDEBUG_SESSION") {


### PR DESCRIPTION
See: https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/#Defeating-the-Attack-using-NGINX-and-NGINX-Plus