### PR TITLE
Don't import the `services.yaml` in the `config.yaml`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: services.yaml }
     - { resource: 'local/' }
 
 


### PR DESCRIPTION
It already gets imported via the [`Kernel`](https://github.com/pimcore/pimcore/blob/9d82ae1a5c5806406344d75445b3d3a1f8adb47e/lib/Kernel.php#L123-L125) (after the config was loaded). 
If it's imported in the `config.yaml` too, it gets loaded twice (once before the config via `config.yaml` and then again after the config via the Kernel).