### PR TITLE
docker-compose: use proper redis configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 services:
     redis:
         image: redis:alpine
+        command: [ redis-server, --maxmemory 128mb, --maxmemory-policy volatile-lru, --save "" ]
 
     db:
         image: mariadb:10.5


### PR DESCRIPTION
Without this config Redis could cause OOM on the Docker host. 