### PR TITLE
Fix varaible name in explaining comment

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -115,7 +115,7 @@ server {
     location ~ ^/index\.php(/|$) {
         send_timeout 1800;
         fastcgi_read_timeout 1800;
-        # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+        # regex to split $uri to $fastcgi_script_name and $fastcgi_path_info
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # Check that the PHP script exists before passing it
         #try_files $fastcgi_script_name =404;


### PR DESCRIPTION
Fixes a variable name in the explaining comment of [fastcgi_split_path_info](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_split_path_info).

See pimcore/pimcore#11556