### PR TITLE
Add default configuration for APP_DEBUG + PIMCORE_DEV_MODE

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,8 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
+APP_DEBUG=false
+PIMCORE_DEV_MODE=false
 
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'


### PR DESCRIPTION
Currently people have to look up in the docs how to enable / disable debug / dev mode.
With this PR the default settings are added to `.env` file so it is obvious to everybody how to change those debug settings.

Background: For one project we had an `.env.local` file which defined `APP_ENV=prod`. Nevertheless the debug mode got enabled accidentically (in this case it was Pimcore 6.9 but I could imagine that this is also possible with Pimcore X when `APP_DEBUG=false` gets set in `.env` accidentically). Of course also with this PR this would be possible but at least it is obvious which environment settings can be used to configure the behaviour.

An alternative idea: In which use case does it make sense to allow `APP_DEBUG=true` or `PIMCORE_DEV_MODE=true` when `APP_ENV` is not one of https://github.com/pimcore/pimcore/blob/5de6239c6b6c04fb7d6823f2721eacd7a279ebf7/lib/Kernel.php#L404-L407? Because we only load the Symfony debug bundle when one of those environments gets used but for example in https://github.com/pimcore/pimcore/blob/10.x/lib/Mail.php#L235 we respect debug mode? Why this inconsistency?