### PR TITLE
Remove deprecated MariaDB config options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     db:
         image: mariadb:10.5
         working_dir: /application
-        command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-format=Barracuda, --innodb-large-prefix=1, --innodb-file-per-table=1]
+        command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-per-table=1]
         volumes:
             - pimcore-demo-database:/var/lib/mysql
         environment:


### PR DESCRIPTION
[`innodb-file-format`](https://mariadb.com/kb/en/innodb-system-variables/#innodb_file_format) and [`innodb-large-prefix`](https://mariadb.com/kb/en/innodb-system-variables/#innodb_large_prefix) are deprecated and removed in MariaDB 10.6. Their default values are the ones that were used here.

[`innodb-file-per-table`](https://mariadb.com/kb/en/innodb-system-variables/#innodb_file_per_table) is `on` by default, too, but as it is not deprecated, I didn't remove it.