### PR TITLE
APP_DEBUG=true should be the default

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_DEBUG=false
+APP_DEBUG=true
 PIMCORE_DEV_MODE=false
 
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16


### PR DESCRIPTION
Alternative approach #85 
Fixes #85

Since we're using `dev` environment as the default for installing, we should also set the kernel debug flag. 