### PR TITLE
Use php 8.1 when testing test project

### DIFF
--- a/.github/workflows/pimcore-skeleton.yml
+++ b/.github/workflows/pimcore-skeleton.yml
@@ -45,7 +45,7 @@ jobs:
           --volume=${{ github.workspace }}/:/test/ \
           --workdir=/test/ \
           --user=$(id -u):$(id -g) \
-          docker.io/pimcore/pimcore:PHP8.0-fpm \
+          docker.io/pimcore/pimcore:PHP8.1-fpm \
             composer create-project \
               pimcore/skeleton:@dev \
               --repository='{"type": "path", "url": "./skeleton"}' \


### PR DESCRIPTION
A little bug has slipped through with #75 . We want to use php 8.1 when creating the project in the test action.