### PR TITLE
Fix PHP-FPM status/ping routes in nginx config

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -149,6 +149,7 @@ server {
     location /fpm- {
         access_log off;
         include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         location /fpm-status {
             allow 127.0.0.1;
             # add additional IP's or Ranges


### PR DESCRIPTION
The PHP-FPM status/ping routes need the `SCRIPT_FILENAME` FastCGI param to be set for PHP-FPM to recognize them.

This can either be done by including the `fastcgi.conf` (which is not available on all systems) instead of `fastcgi_params` or, if the latter is used, manually like in this PR.

Docs PR: pimcore/pimcore#11842