### PR TITLE
Remove unused dev dependency `cache/integration-tests`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "pimcore/pimcore": "^10.0"
   },
   "require-dev": {
-    "cache/integration-tests": "^0.17.0",
     "codeception/codeception": "^4.1.12",
     "codeception/module-symfony": "^1"
   },


### PR DESCRIPTION
I don't think we need this. It was added in https://github.com/pimcore/skeleton/commit/e0762b51be0a304f347ac7c56367d46c09b5b02f without further explanation and updated in #43, but as far as I can see it's not used in this repo and from the description it's useful if you want to test your custom PSR-6 or PSR-16 implementation - which I assume most Pimcore projects don't create.