### PR TITLE
Remove `codeception/module-symfony` dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "pimcore/pimcore": "^10.0"
   },
   "require-dev": {
-    "codeception/codeception": "^4.1.12",
-    "codeception/module-symfony": "^1"
+    "codeception/codeception": "^4.1.12"
   },
   "suggest": {
     "pimcore/data-hub": "Universal data interface for GraphQL, CSV and other formats"


### PR DESCRIPTION
This was removed in pimcore/pimcore#11756, which will be released with Pimcore 10.4.