### PR TITLE
Remove separate PHP debug container

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -9,10 +9,6 @@ upstream php-pimcore10 {
     server php-fpm:9000;
 }
 
-upstream php-pimcore10-debug {
-    server php-fpm-debug:9000;
-}
-
 map $args $static_page_root {
     default                                 /var/tmp/pages;
     "~*(^|&)pimcore_editmode=true(&|$)"     /var/nonexistent;
@@ -141,11 +137,6 @@ server {
 
         # Mitigate https://httpoxy.org/ vulnerabilities
         fastcgi_param HTTP_PROXY "";
-
-        # If Xdebug session is requested, pass it to the Xdebug enabled container
-        if ($http_cookie ~* "XDEBUG_SESSION") {
-            fastcgi_pass php-pimcore10-debug;
-        }
 
         fastcgi_pass php-pimcore10;
         # Prevents URIs that include the front controller. This will 404:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,30 +24,17 @@ services:
             - ./.docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
         depends_on:
             - php-fpm
-            - php-fpm-debug
 
     php-fpm:
         #user: '1000:1000' # set to your uid:gid
-        image: pimcore/pimcore:PHP8.1-fpm
-        environment:
-            COMPOSER_HOME: /var/www/html
-        depends_on:
-            - db
-        volumes:
-            - .:/var/www/html
-            - pimcore-tmp-storage:/tmp
-
-    php-fpm-debug:
-        #user: '1000:1000' # set to your uid:gid
         image: pimcore/pimcore:PHP8.1-fpm-debug
+        environment:
+            COMPOSER_HOME: /var/www/html
+            PHP_IDE_CONFIG: serverName=localhost
         depends_on:
             - db
         volumes:
             - .:/var/www/html
-            - pimcore-tmp-storage:/tmp
-        environment:
-            PHP_IDE_CONFIG: serverName=localhost
-            COMPOSER_HOME: /var/www/html
 
     supervisord:
         #user: '1000:1000' # set to your uid:gid
@@ -58,7 +45,5 @@ services:
             - .:/var/www/html
             - ./.docker/supervisord.conf:/etc/supervisor/conf.d/pimcore.conf:ro
 
-
 volumes:
     pimcore-database:
-    pimcore-tmp-storage:


### PR DESCRIPTION
I don't think it's necessary to have a separate debug container, as Xdebug supports this out of the box. You just have to start it on demand, instead of eagerly with every request. It should have a minimal overhead (in `v3`) when not enabled ([via cookie or env variable](https://xdebug.org/docs/step_debug#activate_debugger)).