### PR TITLE
Support static pages in nginx

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -11,6 +11,13 @@ upstream php-pimcore10-debug {
     server php-fpm-debug:9000;
 }
 
+map $args $static_page_root {
+    default                                 /var/tmp/pages;
+    "~*(^|&)pimcore_editmode=true(&|$)"     /var/nonexistent;
+    "~*(^|&)pimcore_preview=true(&|$)"      /var/nonexistent;
+    "~*(^|&)pimcore_version=[^&]+(&|$)"     /var/nonexistent;
+}
+
 server {
     listen [::]:80 default_server;
     listen 80 default_server;
@@ -103,17 +110,9 @@ server {
         add_header Cache-Control "public";
     }
 
-    location @staticpage{
-        try_files /var/tmp/pages$uri.html $uri /index.php$is_args$args;
-    }
-
     location / {
         error_page 404 /meta/404;
-        error_page 418 = @staticpage;
-        if ($args ~* ^(?!pimcore_editmode=true|pimcore_preview|pimcore_version)(.*)$){
-            return 418;
-        }
-        try_files $uri /index.php$is_args$args;
+        try_files $static_page_root$uri.html $uri /index.php$is_args$args;
     }
 
     # Use this location when the installer has to be run

--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -103,8 +103,16 @@ server {
         add_header Cache-Control "public";
     }
 
+    location @staticpage{
+        try_files /var/tmp/pages$uri.html $uri /index.php$is_args$args;
+    }
+
     location / {
         error_page 404 /meta/404;
+        error_page 418 = @staticpage;
+        if ($args ~* ^(?!pimcore_editmode=true|pimcore_preview|pimcore_version)(.*)$){
+            return 418;
+        }
         try_files $uri /index.php$is_args$args;
     }
 


### PR DESCRIPTION
Currently, static pages are only supported in the (unused) `.htaccess` config (since #58).

This PR adds support for static pages in nginx.