### PR TITLE
Stick to Symfony best practice by avoiding @Template annotation

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -3,20 +3,17 @@
 namespace App\Controller;
 
 use Pimcore\Controller\FrontendController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends FrontendController
 {
     /**
-     * @Template
-     *
      * @param Request $request
-     *
-     * @return array
+     * @return Response
      */
-    public function defaultAction(Request $request)
+    public function defaultAction(Request $request): Response
     {
-        return [];
+        return $this->render('default/default.html.twig');
     }
 }


### PR DESCRIPTION
Explicitly return a response instead of implicit use of ```@Template``` annotation
as Symfony mentioned in its best practice for controllers:

  https://symfony.com/doc/current/best_practices.html#don-t-use-annotations-to-configure-the-controller-template