### PR TITLE
Provide controller / route to automatically get redirected to /admin

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -20,6 +20,6 @@ class DefaultController extends FrontendController
     
     public function loginAction(): Response
     {
-        return $this->forward(LoginController::class.'::loginAction');
+        return $this->forward(LoginController::class.'::loginCheckAction');
     }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -18,7 +18,11 @@ class DefaultController extends FrontendController
         return $this->render('default/default.html.twig');
     }    
     
+    /**
+     * Forwards the request to admin login
+     */
     public function loginAction(): Response
+    {
     {
         return $this->forward(LoginController::class.'::loginCheckAction');
     }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -15,5 +15,14 @@ class DefaultController extends FrontendController
     public function defaultAction(Request $request): Response
     {
         return $this->render('default/default.html.twig');
+    }    
+    
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function loginAction(Request $request)
+    {
+        return $this->forward(LoginController::class.'::loginAction');
     }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -17,11 +17,7 @@ class DefaultController extends FrontendController
         return $this->render('default/default.html.twig');
     }    
     
-    /**
-     * @param Request $request
-     * @return Response
-     */
-    public function loginAction(Request $request)
+    public function loginAction(): Response
     {
         return $this->forward(LoginController::class.'::loginAction');
     }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use Pimcore\Bundle\AdminBundle\Controller\Admin\LoginController;
 use Pimcore\Controller\FrontendController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
As written in https://github.com/pimcore/skeleton/issues/39 lots of clients use Pimcore without any frontend application but as pure PIM / MDM systems. But as we did not find a working general solution which differentiates between pure PIM systems and Pimcores with frontend in https://github.com/pimcore/skeleton/pull/59 - this PR is a compromise. It provides a controller which can be selected for the `/Home` document. With this accessing `<Domain>` will automatically redirect to the Pimcore admin area at `<Domain>/admin`.

Resolves #39