### PR TITLE
Revert "Remove `codeception/module-symfony` dev dependency"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "pimcore/pimcore": "^10.5"
   },
   "require-dev": {
-    "codeception/codeception": "^4.1.12"
+    "codeception/codeception": "^4.1.12",
+    "codeception/module-symfony": "^1"
   },
   "suggest": {
     "pimcore/data-hub": "Universal data interface for GraphQL, CSV and other formats"


### PR DESCRIPTION
This reverts commit a742e7fa0c7ddbf8aab8881a562b05426b1ee2bb.

Related to https://github.com/pimcore/pimcore/pull/13762