### PR TITLE
[Bug]: Adding `system.template.yml` to fix `twig_matches` error

### DIFF
--- a/var/config/system.template.yml
+++ b/var/config/system.template.yml
@@ -1,0 +1,32 @@
+pimcore:
+    general:
+        domain: ''
+        redirect_to_maindomain: false
+        language: en
+        valid_languages: 'en'
+        fallback_languages:
+            en: ''
+        default_language: ''
+        debug_admin_translations: false
+    documents:
+        versions:
+            days: null
+            steps: 10
+        error_pages:
+            default: null
+    objects:
+        versions:
+            days: null
+            steps: 10
+    assets:
+        versions:
+            days: null
+            steps: 10
+        hide_edit_image: false
+        disable_tree_preview: false
+pimcore_admin:
+    branding:
+        login_screen_invert_colors: false
+        color_login_screen: ''
+        color_admin_interface: ''
+        login_screen_custom_image: ''


### PR DESCRIPTION
Resolves #130, #129

### Notes 
Porting the approach from [Demo repository](https://github.com/pimcore/demo/blob/10.2/var/config/system.template.yml) with some minor modifications (eg. removed the languages beside english and default error page)

This [change ](https://github.com/twigphp/Twig/commit/61672c43f97dc2a9197211997e0ec2b1a797444c#diff-29e85e483c6ec4a9c2fd144820b6722c86df60d54175b355d85e806253313c1aR1031) in twig/twig 3.5.0 (2 days ago) made it to work strictly on strings.

Without this `template.yml`, the default node would look like
https://github.com/pimcore/pimcore/blob/b7f8f6669674c496fcb56247f9cea3f2b5e06eb9/bundles/InstallBundle/SystemConfig/ConfigWriter.php#L31-L37
and `login_screen_custom_image` being not defined as an empty string

