### PR TITLE
Consume `pimcore_image_optimize` queue

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -2,7 +2,7 @@
 # Important Notice: this configuration is not optimized for production use!
 
 [program:messenger-consume]
-command=php /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance --memory-limit=250M --time-limit=3600
+command=php /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_image_optimize --memory-limit=250M --time-limit=3600
 numprocs=1
 startsecs=0
 autostart=true


### PR DESCRIPTION
According to https://pimcore.com/docs/pimcore/10.5/Development_Documentation/Getting_Started/Installation.html#page_5-Maintenance-Cron-Job and https://pimcore.com/docs/pimcore/10.5/Development_Documentation/Installation_and_Upgrade/Upgrade_Notes/index.html#page_10-4-0 this queue should be consumed since Pimcore `10.4`.