### PR TITLE
Update .gitignore: Remove obsolete ignore for debug-mode.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 
 !/var/config
 /var/config/system.yml
-/var/config/debug-mode.php
 /var/config/maintenance.php
 
 # project specific recommendations


### PR DESCRIPTION
The `var/config/debug-mode.php` file has been removed in Pimcore 10 by pimcore/pimcore@d2c40d5d316b0068d63753e49b7834e95e63c491