### PR TITLE
Adapt call to pimcore:maintenance to Pimcore 11

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -13,7 +13,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:maintenance]
-command=bash -c 'sleep 3600 && exec php /var/www/html/bin/console pimcore:maintenance --async'
+command=bash -c 'sleep 3600 && exec php /var/www/html/bin/console pimcore:maintenance'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1


### PR DESCRIPTION
In Pimcore 11 (which this repo requires), the `--async` flag in the `pimcore:maintenance` command was [removed](https://github.com/pimcore/pimcore/pull/13042).