### PR TITLE
Kick duplicate nginx image/avif config

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,9 +1,6 @@
 
 # mime types are already covered in nginx.conf
 #include mime.types;
-types {
-    image/avif avif;
-}
 
 upstream php-pimcore10 {
     server php:9000;


### PR DESCRIPTION
Resolves #161

### Additional Info
The config was added temporarily to fix the avif formats and now available in the stable image. please see https://github.com/pimcore/skeleton/pull/95#discussion_r869242356