### PR TITLE
Fixed links in default templates to Pimcore 11 Documentation

### DIFF
--- a/templates/default/default.html.twig
+++ b/templates/default/default.html.twig
@@ -108,8 +108,8 @@
 
     {% if editmode %}
         <div class="buttons">
-            <a target="_blank" href="https://pimcore.com/docs/6.x/Development_Documentation/Getting_Started/Installation.html">Install Sample Data / Boilerplate</a>
-            <a target="_blank" href="https://pimcore.com/docs/6.x/Development_Documentation/Getting_Started/index.html">Getting Started</a>
+            <a target="_blank" href="https://pimcore.com/docs/platform/Pimcore/Getting_Started/Installation/Webserver_Installation">Install Sample Data / Boilerplate</a>
+            <a target="_blank" href="https://pimcore.com/docs/platform/Pimcore/Getting_Started">Getting Started</a>
         </div>
 
         <div class="info">


### PR DESCRIPTION
Hi,

Small change for getting actual links in default.html.twig. As I see, they still present form 6.x documentation and configured redirects to Pimcore 11 Documentation, but they don't work. For ex., 1st link redirects to https://pimcore.com/docs/platform/Pimcore/Getting_Started/Installation/ and it's Forbidden:
![Screenshot 2023-12-11 at 08 47 31](https://github.com/pimcore/skeleton/assets/5318027/f3931484-8b9b-402f-8fc3-401e0e87a2ce)

I suggest to update them and getting smooth start :)

Please review, 