### PR TITLE
Add RabbitMQ to docker-compose.yaml (#186)

### DIFF
--- a/.docker/messenger.yaml
+++ b/.docker/messenger.yaml
@@ -1,0 +1,8 @@
+framework:
+    messenger:
+        transports:
+            pimcore_core: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_core'
+            pimcore_maintenance: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_maintenance'
+            pimcore_scheduled_tasks: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_scheduled_tasks'
+            pimcore_image_optimize: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_image_optimize'
+            pimcore_asset_update: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_asset_update'

--- a/.docker/messenger.yaml
+++ b/.docker/messenger.yaml
@@ -1,8 +1,8 @@
 framework:
     messenger:
         transports:
-            pimcore_core: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_core'
-            pimcore_maintenance: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_maintenance'
-            pimcore_scheduled_tasks: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_scheduled_tasks'
-            pimcore_image_optimize: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_image_optimize'
-            pimcore_asset_update: '%env(MESSENGER_TRANSPORT_DSN)%pimcore_asset_update'
+            pimcore_core: 'amqp://rabbitmq:5672/%2f/pimcore_core'
+            pimcore_maintenance: 'amqp://rabbitmq:5672/%2f/pimcore_maintenance'
+            pimcore_scheduled_tasks: 'amqp://rabbitmq:5672/%2f/pimcore_scheduled_tasks'
+            pimcore_image_optimize: 'amqp://rabbitmq:5672/%2f/pimcore_image_optimize'
+            pimcore_asset_update: 'amqp://rabbitmq:5672/%2f/pimcore_asset_update'

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,11 @@
   },
   "prefer-stable": true,
   "require": {
-    "pimcore/pimcore": "^11.1",
     "pimcore/admin-ui-classic-bundle": "^1.2",
-    "symfony/runtime": "^6.2",
-    "symfony/dotenv": "^6.2"
+    "pimcore/pimcore": "^11.1",
+    "symfony/amqp-messenger": "^5.4",
+    "symfony/dotenv": "^6.2",
+    "symfony/runtime": "^6.2"
   },
   "require-dev": {
     "codeception/codeception": "^5.0.3",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   },
   "prefer-stable": true,
   "require": {
-    "pimcore/admin-ui-classic-bundle": "^1.2",
     "pimcore/pimcore": "^11.1",
-    "symfony/amqp-messenger": "^5.4",
+    "pimcore/admin-ui-classic-bundle": "^1.2",
+    "symfony/amqp-messenger": "^6.2",
     "symfony/dotenv": "^6.2",
     "symfony/runtime": "^6.2"
   },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,6 @@ services:
         environment:
             COMPOSER_HOME: /var/www/html
             PHP_IDE_CONFIG: serverName=localhost
-            MESSENGER_TRANSPORT_DSN: amqp://guest:guest@rabbitmq:5672/%2f/
             # Feed installer configuration via ENV variables.
             # See: https://pimcore.com/docs/pimcore/current/Development_Documentation/Getting_Started/Advanced_Installation_Topics.html#page_Advanced-Installation-Topics
             PIMCORE_INSTALL_MYSQL_USERNAME: pimcore
@@ -61,8 +60,6 @@ services:
     supervisord:
         #user: '1000:1000' # set to your uid:gid
         image: pimcore/pimcore:php8.2-supervisord-latest
-        environment:
-            MESSENGER_TRANSPORT_DSN: amqp://guest:guest@rabbitmq:5672/%2f/
         depends_on:
             rabbitmq:
                 condition: service_started

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
         image: redis:alpine
         command: [ redis-server, --maxmemory 128mb, --maxmemory-policy volatile-lru, --save "" ]
 
+    rabbitmq:
+        image: rabbitmq:alpine
+
     db:
         image: mariadb:10.11
         working_dir: /application
@@ -40,6 +43,7 @@ services:
         environment:
             COMPOSER_HOME: /var/www/html
             PHP_IDE_CONFIG: serverName=localhost
+            MESSENGER_TRANSPORT_DSN: amqp://guest:guest@rabbitmq:5672/%2f/
             # Feed installer configuration via ENV variables.
             # See: https://pimcore.com/docs/pimcore/current/Development_Documentation/Getting_Started/Advanced_Installation_Topics.html#page_Advanced-Installation-Topics
             PIMCORE_INSTALL_MYSQL_USERNAME: pimcore
@@ -52,15 +56,21 @@ services:
                 condition: service_healthy
         volumes:
             - .:/var/www/html
+            - ./.docker/messenger.yaml:/var/www/html/config/packages/messenger.yaml:ro
 
     supervisord:
         #user: '1000:1000' # set to your uid:gid
         image: pimcore/pimcore:php8.2-supervisord-latest
+        environment:
+            MESSENGER_TRANSPORT_DSN: amqp://guest:guest@rabbitmq:5672/%2f/
         depends_on:
+            rabbitmq:
+                condition: service_started
             db:
                 condition: service_healthy
         volumes:
             - .:/var/www/html
+            - ./.docker/messenger.yaml:/var/www/html/config/packages/messenger.yaml:ro
             - ./.docker/supervisord.conf:/etc/supervisor/conf.d/pimcore.conf:ro
 
     # The following two services are used for testing.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
 
     rabbitmq:
         image: rabbitmq:alpine
+        volumes:
+            - pimcore-rabbitmq:/var/lib/rabbitmq/
 
     db:
         image: mariadb:10.11
@@ -97,6 +99,7 @@ services:
 
 volumes:
     pimcore-database:
+    pimcore-rabbitmq:
     pimcore-test-database:
     pimcore-test-var:
     pimcore-test-public-var:


### PR DESCRIPTION
Resolves #186

**ATTENTION:** Do not merge this until https://github.com/pimcore/docker/pull/152 has been rolled out as a stable Docker image release!

You can test this PR by replaceing the `php` and `supervisord` image to the current dev version:
```diff
php:
-  image: pimcore/pimcore:php8.2-debug-latest
+  image: pimcore/pimcore:php8.2-debug-v3-dev
supervisord:
  image: pimcore/pimcore:php8.2-supervisord-latest
+  image: pimcore/pimcore:php8.2-supervisord-v3-dev
```

Run `watch -n 1 sudo docker compose exec rabbitmq rabbitmqctl list_queues` to monitor the current queue overview with the pending tasks. For example, upload images to see that `pimcore_asset_update` are being processed.