### PR TITLE
 [Improvement]: Distribute queue into multiple workers in Supervisord conf

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -2,7 +2,7 @@
 # Important Notice: this configuration is not optimized for production use!
 
 [program:messenger-consume]
-command=php /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600
+command=php /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize --memory-limit=250M --time-limit=3600
 numprocs=1
 startsecs=0
 autostart=true
@@ -11,6 +11,18 @@ process_name=%(program_name)s_%(process_num)02d
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+
+[program:consume-asset-update]
+command=php /var/www/html/bin/console messenger:consume pimcore_asset_update --memory-limit=250M --time-limit=3600
+numprocs=1
+startsecs=0
+autostart=true
+autorestart=true
+process_name=%(program_name)s_%(process_num)02d
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
 
 [program:maintenance]
 command=bash -c 'sleep 3600 && exec php /var/www/html/bin/console pimcore:maintenance'


### PR DESCRIPTION
Resolves https://github.com/pimcore/skeleton/issues/150

By looking at https://github.com/pimcore/pimcore/pull/16143#issuecomment-1785324906 , it seems ideal to have a different worker for `pimcore_asset_update`

Notes:
The only queue that would "benefit" from being sequentially processed after previous queue is clear is  `pimcore_search_backend_message`, after `pimcore_scheduled_tasks`, as the published/deleted state could change.
https://github.com/pimcore/pimcore/blob/3ffaeac8d9f07f877ea4f469015be1774de447b9/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data/Dao.php#L81 but in the skeleton the `SimpleBackendSearchBundle` is not enabled by default



