### PR TITLE
Add cache-buster re-write rule to nginx.conf option 2 examples

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -52,11 +52,13 @@ server {
     ### 2. Option - Checking permissions before delivery
     #
     # rewrite ^(/protected/.*) /index.php$is_args$args last;
-    #
+    # 
+    # rewrite ^(/cache-buster-(?:\d+)/protected(?:.*)) /index.php$is_args$args last;
+    # 
     # location ~ ^/var/.*/protected(.*) {
     #   return 403;
     # }
-    #
+    # 
     # location ~ ^/cache-buster\-[\d]+/protected(.*) {
     #   return 403;
     # }


### PR DESCRIPTION
This properly re-routes cache-buster routes to a custom controller when using the "Option 2" nginx example to block access to the protected folder but still allow Portal Engine/etc. users to authenticate and access via custom controller.

See https://github.com/pimcore/pimcore/pull/18074 in the pimcore/pimcore repo.