### PR TITLE
Added scheduled sync to paas-skeleton

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yaml
+++ b/.github/workflows/sync-changes-scheduled.yaml
@@ -1,0 +1,23 @@
+name: Sync changes scheduled from skeleton to paas-skeleton
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '30 21 * * *'
+
+jobs:
+  sync-branches:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-sync-changes.yaml@main
+    if: github.repository == 'pimcore/skeleton'
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [{'base': '2025.x', 'destination': '2025.x'}]
+    with:
+      base_ref: ${{ matrix.ref.base }}
+      ref_name: ${{ matrix.ref.destination }}
+      target_repo: 'paas-skeleton'
+      auto_merge: true
+    secrets:
+      SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      GIT_NAME: ${{ secrets.GIT_NAME }}
+      GIT_EMAIL: ${{ secrets.GIT_EMAIL }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate syncing changes from the `skeleton` repository to the `paas-skeleton` repository on a scheduled basis. 

**Automation and CI/CD:**

* Added a scheduled workflow (`.github/workflows/sync-changes-scheduled.yaml`) that triggers both manually and nightly at 21:30 UTC to sync changes from the `2025.x` branch of `skeleton` to the same branch in `paas-skeleton`, using a reusable workflow and secure secrets for authentication.