### PR TITLE
Update platform version requirement to 2025.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "~8.3.0 || ~8.4.0",
     "pimcore/pimcore": "^12.3",
-    "pimcore/platform-version": "2025.x-dev",
+    "pimcore/platform-version": "2025.4",
     "pimcore/admin-ui-classic-bundle": "*",
     "pimcore/quill-bundle": "*",
     "symfony/amqp-messenger": "^6.2 || ^7.2",


### PR DESCRIPTION
This pull request updates the Pimcore platform version requirement in the `composer.json` file to use a specific stable release instead of a development version.

Dependency update:

* Changed the `pimcore/platform-version` requirement from `"2025.x-dev"` to `"2025.4"` in `composer.json`.