### PR TITLE
Add new matrix configuration for 2025.4

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yaml
+++ b/.github/workflows/sync-changes-scheduled.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [{'base': '2025.x', 'destination': '2025.x'}]
+        ref: [{'base': '2025.x', 'destination': '2025.x'}, {'base': '2025.4', 'destination': '2025.4'}]
     with:
       base_ref: ${{ matrix.ref.base }}
       ref_name: ${{ matrix.ref.destination }}


### PR DESCRIPTION
This pull request updates the workflow configuration to support syncing changes across an additional release branch. The main change is an expansion of the matrix strategy in the scheduled sync job.

Workflow configuration update:

* [`.github/workflows/sync-changes-scheduled.yaml`](diffhunk://#diff-adbbadd282595cff2e154c25d6e262d6d382e16c991687db9cf50b11434add28L14-R14): Added the `2025.4` branch to the matrix for the sync job, enabling scheduled syncs for both `2025.x` and `2025.4` branches.