### PR TITLE
Added intaller profile to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are new to Pimcore, it's better to start with our demo package, listed be
 ```bash
 COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project
 cd ./my-project
-./vendor/bin/pimcore-install
+./vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'
 ```
 
 - Point your virtual host to `my-project/public`
@@ -38,7 +38,7 @@ You don't need to have a PHP environment with composer installed.
     * Start the needed services with `docker compose up -d`
 
 4. Install pimcore and initialize the DB
-    `docker compose exec php vendor/bin/pimcore-install`
+    `docker compose exec php vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'`
     * When asked for admin user and password: Choose freely
     * This can take a while, up to 20 minutes
     * If you select to install the SimpleBackendSearchBundle please make sure to add the `pimcore_search_backend_message` to your `.docker/supervisord.conf` file inside value for 'command' like `pimcore_maintenance` already is.


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to ensure that the correct installation profile is used when setting up a new Pimcore project. The most important changes are:

**Installation instructions update:**

* Updated the standard installation command to include the `--install-profile='App\Installer\SkeletonProfile'` flag, ensuring the correct profile is used during setup.
* Updated the Docker-based installation command to also include the `--install-profile='App\Installer\SkeletonProfile'` flag for consistency and correct setup.