### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ If you are new to Pimcore, it's better to start with our demo package, listed be
 
 ## Getting started
 ```bash
-COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project ">=2026"
+COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project ">=2026" --no-scripts
 cd ./my-project
 ./vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'
 ```
@@ -28,14 +28,14 @@ You don't need to have a PHP environment with composer installed.
 
 ### Follow these steps
 1. Initialize the skeleton project using the `pimcore/pimcore` image
-`docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.3-latest composer create-project pimcore/skeleton my-project ">=2026"`
+`docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.3-latest composer create-project pimcore/skeleton my-project ">=2026" --no-scripts`
 
 2. Go to your new project
 `cd my-project/`
 
 3. Part of the new project is a docker compose file
     * Run `sed -i "s|#user: '1000:1000'|user: '$(id -u):$(id -g)'|g" docker-compose.yaml` to set the correct user id and group id.
-    * Start the needed services with `docker compose up -d`
+    * Start the necessary services with `docker compose up -d`
 
 4. Install pimcore and initialize the DB
     `docker compose exec php vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'`
@@ -51,7 +51,7 @@ You don't need to have a PHP environment with composer installed.
 6. :heavy_check_mark: DONE - You can now visit your pimcore instance:
     * The frontend: <http://localhost>
     * The admin interface, using the credentials you have chosen above:
-      <http://localhost/admin>
+      <http://localhost/pimcore-studio/login>
 
 ## Pimcore Platform Version
 By default, Pimcore Platform Version is added as a dependency which ensures installation of compatible and in combination 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You don't need to have a PHP environment with composer installed.
 
 ### Follow these steps
 1. Initialize the skeleton project using the `pimcore/pimcore` image
-``docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.3-latest composer create-project pimcore/skeleton my-project``
+`docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.3-latest composer create-project pimcore/skeleton my-project ">=2026"`
 
 2. Go to your new project
 `cd my-project/`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ If you are new to Pimcore, it's better to start with our demo package, listed be
 
 ## Getting started
 ```bash
-COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project
+COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project ">=2026"
 cd ./my-project
 ./vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'
 ```


### PR DESCRIPTION
## Version constraint for composer create-project

If the version constraint is omitted, it may install `2025.4` version, e.g. if you have PHP 8.3 installed. And then the step
> ./vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'

will fail with error
> The "--install-profile" option does not exist.

With this PR, you will get
> Cannot use pimcore/skeleton's latest version v2026.1.0 as it requires php ~8.4.0 || ~8.5.0 which is not satisfied by your platform.

Alternative approach:
We could add `--install-profile` as dummy option in `2025.4`, then it will not error. But imho it is a good idea to specify the Pimcore Platform version to be installed.

##  --no-scripts for create-project
`composer create-project` also runs the scripts from [`post-install-cmd`](https://github.com/pimcore/skeleton/blob/41c3dbef14bc4e5d7bf016cd29a86b960758c3a3/composer.json#L46). This does not make sense as Pimcore is not installed yet and executing it on the host and not in Docker does make even less sense - in my case it caused error
> PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 2621440 bytes) in /Users/janwalther/PhpstormProjects/skeleton/my-project/vendor/symfony/framework-bundle/DependencyInjection/  
  Compiler/ContainerBuilderDebugDumpPass.php on line 52  
during `cache:clear`

## Use Studio UI login url
`http:localhost/admin` does not exist anymore, we need to use http://localhost/pimcore-studio/login now.