### PR TITLE
Remove `PIMCORE_SKIP_DOTENV_FILE` in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,9 +6,8 @@ define('PIMCORE_PROJECT_ROOT', dirname(__DIR__));
 const PROJECT_ROOT = PIMCORE_PROJECT_ROOT;
 
 // set the used pimcore/symfony environment
-foreach (['APP_ENV' => 'test', 'PIMCORE_SKIP_DOTENV_FILE' => true] as $name => $value) {
-    putenv("{$name}={$value}");
-    $_ENV[$name] = $_SERVER[$name] = $value;
+foreach (['APP_ENV' => 'test'] as $name => $value) {
+    putenv("{$name}=" . $_ENV[$name] = $_SERVER[$name] = $value);
 }
 require_once PIMCORE_PROJECT_ROOT . '/vendor/autoload.php';
 


### PR DESCRIPTION
It has been removed in Pimcore 11 with pimcore/pimcore#14318.