### PR TITLE
Remove 'pimcore_index_queues' from consume command

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -2,7 +2,7 @@
 # Important Notice: this configuration is not optimized for production use!
 
 [program:messenger-consume]
-command=php /var/www/html/bin/console messenger:consume pimcore_index_queues pimcore_generic_data_index_queue scheduler_generic_data_index pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update pimcore_generic_execution_engine --memory-limit=250M --time-limit=3600
+command=php /var/www/html/bin/console messenger:consume pimcore_generic_data_index_queue scheduler_generic_data_index pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update pimcore_generic_execution_engine --memory-limit=250M --time-limit=3600
 numprocs=1
 startsecs=0
 autostart=true


### PR DESCRIPTION
Used by data-hub-simple-rest e.g., that isnt part of the skeleton