### PR TITLE
Update README to match the shipped skeleton and new installer (#19179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd ./my-project
 
 - Point your virtual host to `my-project/public`
 - [Only for Apache] Create `my-project/public/.htaccess` according to https://pimcore.com/docs/platform/Pimcore/Installation_and_Upgrade/System_Setup_and_Hosting/Apache_Configuration/ 
-- Open https://your-host/admin in your browser
+- Open https://your-host/pimcore-studio in your browser
 - Done! 😎
 
 ## Docker
@@ -33,15 +33,20 @@ You don't need to have a PHP environment with composer installed.
 2. Go to your new project
 `cd my-project/`
 
-3. Part of the new project is a docker compose file
-    * Run `sed -i "s|#user: '1000:1000'|user: '$(id -u):$(id -g)'|g" docker-compose.yaml` to set the correct user id and group id.
-    * Start the needed services with `docker compose up -d`
+3. Part of the new project is a docker compose file that already defines every required service
+   (PHP, Nginx, MariaDB, Redis, RabbitMQ, OpenSearch, Mercure, and a Supervisord service that runs
+   the messenger workers). You do not need to add any services yourself.
+    * Run `sed -i "s|user: '1000:1000'|user: '$(id -u):$(id -g)'|g" docker-compose.yaml` to set the correct user id and group id.
+    * Start the services with `docker compose up -d`
 
 4. Install pimcore and initialize the DB
     `docker compose exec php vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'`
-    * When asked for admin user and password: Choose freely
-    * This can take a while, up to 20 minutes
-    * If you select to install the SimpleBackendSearchBundle please make sure to add the `pimcore_search_backend_message` to your `.docker/supervisord.conf` file inside value for 'command' like `pimcore_maintenance` already is.
+    * The committed `.env` already provides the database, OpenSearch, RabbitMQ, Mercure, and admin
+      values, so the installer does not re-prompt for them. It only asks for the **product key**
+      (product registration is mandatory — see <https://license.pimcore.com/register>).
+    * The default admin login is `admin` / `admin` (from `.env`). Change the password after first login.
+    * The installer also builds the search index automatically (a GenericDataIndex post-install command).
+    * This can take a while.
 
 5. Run codeception tests:
    * `docker compose run --user=root --rm test-php chown -R $(id -u):$(id -g) var/ public/var/`
@@ -50,8 +55,8 @@ You don't need to have a PHP environment with composer installed.
 
 6. :heavy_check_mark: DONE - You can now visit your pimcore instance:
     * The frontend: <http://localhost>
-    * The admin interface, using the credentials you have chosen above:
-      <http://localhost/admin>
+    * Pimcore Studio, using the credentials from `.env` (default `admin` / `admin`):
+      <http://localhost/pimcore-studio>
 
 ## Pimcore Platform Version
 By default, Pimcore Platform Version is added as a dependency which ensures installation of compatible and in combination 


### PR DESCRIPTION
## Summary

Updates the skeleton `README.md` so the Docker getting-started instructions match the package's
shipped `.env` and the new profile-based installer. Companion to the documentation fixes for
pimcore/pimcore#19179.

## Changes

- Point users to `/pimcore-studio` instead of the legacy `/admin` interface.
- Clarify that the committed `.env` already provides the database, OpenSearch, RabbitMQ, Mercure,
  and admin credentials, so the installer only prompts for the product key (and the default login
  is `admin` / `admin`).
- Note that the installer builds the search index automatically, and remove the outdated
  SimpleBackendSearchBundle / Supervisord instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
