### PR TITLE
Fix transport config

### DIFF
--- a/.docker/messenger.yaml
+++ b/.docker/messenger.yaml
@@ -1,8 +1,0 @@
-framework:
-    messenger:
-        transports:
-            pimcore_core: 'amqp://rabbitmq:5672/%2f/pimcore_core'
-            pimcore_maintenance: 'amqp://rabbitmq:5672/%2f/pimcore_maintenance'
-            pimcore_scheduled_tasks: 'amqp://rabbitmq:5672/%2f/pimcore_scheduled_tasks'
-            pimcore_image_optimize: 'amqp://rabbitmq:5672/%2f/pimcore_image_optimize'
-            pimcore_asset_update: 'amqp://rabbitmq:5672/%2f/pimcore_asset_update'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,6 @@ services:
                 condition: service_healthy
         volumes:
             - .:/var/www/html
-            - ./.docker/messenger.yaml:/var/www/html/config/packages/messenger.yaml:ro
 
     supervisord:
         #user: '1000:1000' # set to your uid:gid
@@ -64,7 +63,6 @@ services:
                 condition: service_healthy
         volumes:
             - .:/var/www/html
-            - ./.docker/messenger.yaml:/var/www/html/config/packages/messenger.yaml:ro
             - ./.docker/supervisord.conf:/etc/supervisor/conf.d/pimcore.conf:ro
 
     mercure:


### PR DESCRIPTION
Fix #264: messenger.yaml mounted empty in php/supervisord containers

.docker/messenger.yaml was bind-mounted over config/packages/messenger.yaml, a path that doesn't exist in the repo. Docker has to synthesize that mount point, and on some setups the nested single-file bind resolves to an empty file inside the container.

It also turns out the file is redundant: since the 2026.1 migration, Pimcore core builds the pimcore_core, pimcore_maintenance, pimcore_scheduled_tasks, pimcore_image_optimize and pimcore_asset_update transports from PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX, which the committed .env already sets to RabbitMQ. .docker/messenger.yaml just duplicated those same five transports - leftover from the Pimcore 11.x setup (#186) that was never removed.

Fix: delete .docker/messenger.yaml and its two bind mounts. Transport configuration now comes solely from .env + core, which is the intended 2026.x mechanism. 