### PR TITLE
Add optional thumbnail generation overload protection to nginx.conf

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -18,6 +18,15 @@ map $uri $static_page_uri {
     "/"                                     /%home;
 }
 
+# Thumbnail Generation Overload Protection (optional)
+# If your application has pages with a lot of images processed by an image pipeline,
+# on-demand thumbnail generation can overload the server due to too many parallel
+# PHP processes, especially with large source images.
+# To protect against this, uncomment the zone below (adjust the rate to your server's
+# capacity) together with the rate-limited "Thumbnails" location in the server block.
+# See: https://www.nginx.com/blog/rate-limiting-nginx/
+#limit_req_zone $server_name zone=imggen:1M rate=5r/s;
+
 server {
     listen [::]:80 default_server;
     listen 80 default_server;
@@ -104,6 +113,25 @@ server {
         access_log off;
         add_header Cache-Control "public";
     }
+
+    # Thumbnail Generation Overload Protection (optional)
+    # Rate-limited variant of the "Thumbnails" location above: requests exceeding the
+    # rate are queued up to burst=15, additional ones are rejected with HTTP 429.
+    # To enable it, remove the "Thumbnails" location above and uncomment the two
+    # blocks below together with the limit_req_zone directive at the top of this file.
+    #location ~* .*/(image|video)-thumb__\d+__.* {
+    #    try_files /var/tmp/thumbnails$uri @imggen;
+    #    expires 2w;
+    #    access_log off;
+    #    add_header Cache-Control "public";
+    #}
+    #location @imggen {
+    #    limit_req zone=imggen burst=15;
+    #    try_files /var/tmp/thumbnails$uri /index.php;
+    #    expires 2w;
+    #    access_log off;
+    #    add_header Cache-Control "public";
+    #}
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.


### PR DESCRIPTION
Part of pimcore/product-management#1149, as suggested in https://github.com/pimcore/product-management/issues/1149#issuecomment-4863189462.

## What's changed

Moves the *Thumbnail Generation Overload Protection* reference config from the System Setup and Hosting docs (removed in pimcore/platform-version#174) to where it gets used: commented out in `.docker/nginx.conf`, so it stays available as a reference and can be enabled by uncommenting the `limit_req_zone` directive and the rate-limited thumbnail location blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)