### PR TITLE
Add 2026.2 to paas-skeleton sync matrix, fix CLA link in LICENSE.md

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yaml
+++ b/.github/workflows/sync-changes-scheduled.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [{'base': '2026.x', 'destination': '2026.x'}, {'base': '2025.4', 'destination': '2025.4'}]
+        ref: [{'base': '2026.x', 'destination': '2026.x'}, {'base': '2026.2', 'destination': '2026.2'}, {'base': '2025.4', 'destination': '2025.4'}]
     with:
       base_ref: ${{ matrix.ref.base }}
       ref_name: ${{ matrix.ref.destination }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -75,7 +75,7 @@ Pimcore reserves the right to audit, verify and enforce compliance with these te
 1.9 Licensor reserves all rights not expressly granted to Licensee in this Agreement. Except for the limited rights and licenses expressly granted under this Agreement, nothing in this Agreement grants, by implication, waiver, estoppel, or otherwise, to Licensee or any third party any intellectual property rights or other right, title, or interest in or to the Software.
 
 ### 2. CONTRIBUTIONS OF DERIVATIVES
-2.1 If the Customer wishes to contribute to the Software or to distribute a Derivative, both must be made in accordance with the Pimcore Contributors License Agreement (“PCLA”), available at <https://github.com/pimcore/pimcore/blob/12.x/CLA.md>. The PCLA stipulates the terms under which intellectual contributions are managed, ensuring that all parties' rights are protected. Acceptance of the PCLA is mandatory for all contributors and can be reviewed on the source-code repository. Contributions without adherence to the PCLA will not be accepted.
+2.1 If the Customer wishes to contribute to the Software or to distribute a Derivative, both must be made in accordance with the Pimcore Contributors License Agreement (“PCLA”), available at <https://github.com/pimcore/pimcore/blob/2026.x/CLA.md>. The PCLA stipulates the terms under which intellectual contributions are managed, ensuring that all parties' rights are protected. Acceptance of the PCLA is mandatory for all contributors and can be reviewed on the source-code repository. Contributions without adherence to the PCLA will not be accepted.
 
 2.2 Any contribution to the Software by a Derivative must be clearly documented, in order to maintain transparency and integrity of the source code.
     


### PR DESCRIPTION
### Changes

**1. `.github/workflows/sync-changes-scheduled.yaml`** — add `2026.2 → 2026.2` to the paas-skeleton sync matrix.

paas-skeleton already has a `2026.2` branch, but the scheduled sync only covered `2026.x` and `2025.4`, so changes on skeleton's `2026.2` branch would never propagate and the paas branch would silently drift.

Note: `2026.1` was never added to this matrix either, and paas-skeleton has **no** `2026.1` branch at all. It is not included here because the reusable sync workflow (`git rev-list $TARGET_REPO/$TARGET_BRANCH..`) fails when the destination branch doesn't exist — if 2026.1 should be synced too, the branch needs to be created in paas-skeleton first.

**2. `LICENSE.md`** — update the PCLA link from `pimcore/pimcore/blob/12.x/CLA.md` to `blob/2026.x/CLA.md`. The `12.x` branch was renamed, so the old link only works via GitHub's redirect. (Verified `CLA.md` exists on `2026.x`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)