### PR TITLE
Stop the Mercure hub from accepting anonymous subscribers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,7 +73,14 @@ services:
             SERVER_NAME: ':80'
             MERCURE_PUBLISHER_JWT_KEY: 'CHANGE_ME_THIS_IS_MY_SECRET_KEY_THAT_IS_LONG_ENOUGH_FOR_VALIDATION'
             MERCURE_SUBSCRIBER_JWT_KEY: 'CHANGE_ME_THIS_IS_MY_SECRET_KEY_THAT_IS_LONG_ENOUGH_FOR_VALIDATION'
-            MERCURE_EXTRA_DIRECTIVES: anonymous
+            # Deliberately no `anonymous` directive: the hub authorises a subscription once,
+            # when the EventSource connects, from the mercureAuthorization cookie. With
+            # anonymous subscribers allowed, a connection that carries no cookie (or one that
+            # expired while the tab stayed open) is answered 200 OK and then receives nothing,
+            # so Studio keeps what looks like a healthy stream while every notification, job
+            # progress update and agent chat event is dropped. Answering 401 instead makes the
+            # state visible and lets the client re-authorise.
+            MERCURE_EXTRA_DIRECTIVES: ''
         # Uncomment the following line to enable the development mode
         # command: /usr/bin/caddy run -config /etc/caddy/Caddyfile.dev
         ports:


### PR DESCRIPTION
Part of the fix for pimcore/platform-version#346.

## Problem

`MERCURE_EXTRA_DIRECTIVES: anonymous` lets the hub accept a subscription that carries no valid
`mercureAuthorization` cookie. Such a subscription is answered `200 OK` and then **silently
receives nothing**, because every update Studio publishes is a private update.

That turns an authorisation problem into invisible data loss. A Studio tab whose cookie expired
(it lives one hour; the tab lives as long as the user leaves it open) keeps what looks like a
perfectly healthy stream while notifications, job progress and agent chat events are all dropped,
with no error anywhere, until the page is fully reloaded. Measured on a real installation, a tab
ran in that state for five hours across ~31 reconnects.

## Change

Drop the `anonymous` directive. An unauthorised subscription now gets `401`, which the client can
see and react to. Nothing in Pimcore subscribes to the hub anonymously: Studio always holds a
cookie, and pimcore/studio-ui-bundle#4009 makes every reconnect renew it and retry.

## Verification

Started `dunglas/mercure` with `MERCURE_EXTRA_DIRECTIVES: ''` and probed it:

| Subscriber | Before (`anonymous`) | After |
|---|---|---|
| no cookie | `200 OK`, private update **not** delivered | `401` |
| valid subscriber JWT | `200 OK`, delivered | `200 OK`, delivered |
| expired subscriber JWT | `401` | `401` |

The hub starts cleanly with an empty directive list, and authorised delivery is unchanged.

## Not included

The demo ships `.docker/nginx.conf`; the skeleton ships one too, and in both the `location /hub` block has no SSE specific proxy settings (`proxy_buffering off`,
`proxy_read_timeout`, `proxy_http_version 1.1`). That is worth a separate look, but it is a
different concern from this bug and is deliberately left out of this PR: measurements showed the
hub's ~40s heartbeat keeps the stream inside nginx's default 60s idle timeout, so it is hardening
rather than a fix.
